### PR TITLE
Feature/empty scenes support

### DIFF
--- a/src/core/renderer/igpu.ts
+++ b/src/core/renderer/igpu.ts
@@ -20,6 +20,15 @@ class IGPU {
         return this.m_device;
     }
 
+    public static createBuffer(descriptor: GPUBufferDescriptor): GPUBuffer {
+        //create a small buffer in case requested size is 0
+        if (descriptor.size == 0) {
+            descriptor.size = 1024;
+        }
+
+        return this.m_device.createBuffer(descriptor);
+    }
+
     private static m_device: GPUDevice;
 
     private constructor() {}

--- a/src/core/scene/acceleration-structure/tlas.ts
+++ b/src/core/scene/acceleration-structure/tlas.ts
@@ -37,17 +37,19 @@ class TLAS {
 
     public writeNodesToArray(target: ArrayBuffer){
         this.m_tlasNodes.forEach((node, idx) => {
-            let aabbMinArrayF32: Float32Array = new Float32Array(target, idx * TLAS_NODE_SIZE + 0, 4); // padding
-            let aabbMaxArrayF32: Float32Array = new Float32Array(target, idx * TLAS_NODE_SIZE + 16, 4);// padding
-            let leftArrayU32: Uint32Array = new Uint32Array(target, idx * TLAS_NODE_SIZE + 32, 1);
-            let rightArrayU32: Uint32Array = new Uint32Array(target, idx * TLAS_NODE_SIZE + 36, 1);
-            let blasIdxArrayU32: Uint32Array = new Uint32Array(target, idx * TLAS_NODE_SIZE + 40, 2); // padding
-
-            aabbMinArrayF32.set([node.aabb.min.x, node.aabb.min.y, node.aabb.min.z, 0]);
-            aabbMaxArrayF32.set([node.aabb.max.x, node.aabb.max.y, node.aabb.max.z, 0]);
-            leftArrayU32.set([node.left]);
-            rightArrayU32.set([node.right]);
-            blasIdxArrayU32.set([node.blas, 0]);
+            if (node != undefined) {
+                let aabbMinArrayF32: Float32Array = new Float32Array(target, idx * TLAS_NODE_SIZE + 0, 4); // padding
+                let aabbMaxArrayF32: Float32Array = new Float32Array(target, idx * TLAS_NODE_SIZE + 16, 4);// padding
+                let leftArrayU32: Uint32Array = new Uint32Array(target, idx * TLAS_NODE_SIZE + 32, 1);
+                let rightArrayU32: Uint32Array = new Uint32Array(target, idx * TLAS_NODE_SIZE + 36, 1);
+                let blasIdxArrayU32: Uint32Array = new Uint32Array(target, idx * TLAS_NODE_SIZE + 40, 2); // padding
+    
+                aabbMinArrayF32.set([node.aabb.min.x, node.aabb.min.y, node.aabb.min.z, 0]);
+                aabbMaxArrayF32.set([node.aabb.max.x, node.aabb.max.y, node.aabb.max.z, 0]);
+                leftArrayU32.set([node.left]);
+                rightArrayU32.set([node.right]);
+                blasIdxArrayU32.set([node.blas, 0]);
+            }
         });
     }
 

--- a/src/core/scene/scene-data-manager.ts
+++ b/src/core/scene/scene-data-manager.ts
@@ -190,12 +190,12 @@ class SceneDataManager {
     private m_texture: GPUTexture;
 
     private _updateVertexBuffer(): void {
-        this.m_vertexBuffer = IGPU.get().createBuffer({
+        this.m_vertexBuffer = IGPU.createBuffer({
             size: this.m_points.byteLength,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
         });
 
-        this.m_vertexInfoBuffer = IGPU.get().createBuffer({
+        this.m_vertexInfoBuffer = IGPU.createBuffer({
             size: this.m_vertexInfo.byteLength,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
         });
@@ -229,19 +229,19 @@ class SceneDataManager {
         });
 
         // create gpu resources
-        this.m_blasBuffer = IGPU.get().createBuffer({
+        this.m_blasBuffer = IGPU.createBuffer({
             size: blasArrayF32.byteLength,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
         });
         IGPU.get().queue.writeBuffer(this.m_blasBuffer, 0, blasArrayF32);
 
-        this.m_triangleIdxBuffer = IGPU.get().createBuffer({
+        this.m_triangleIdxBuffer = IGPU.createBuffer({
             size: triangleIdxArrayU32.byteLength,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
         });
         IGPU.get().queue.writeBuffer(this.m_triangleIdxBuffer, 0, triangleIdxArrayU32);
 
-        this.m_blasInstanceBuffer = IGPU.get().createBuffer({
+        this.m_blasInstanceBuffer = IGPU.createBuffer({
             size: blasInstanceArrayByte.byteLength,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
         });
@@ -263,7 +263,7 @@ class SceneDataManager {
             });
         });
 
-        this.m_materialBuffer = IGPU.get().createBuffer({
+        this.m_materialBuffer = IGPU.createBuffer({
             size: materialArrayByte.byteLength,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
         });
@@ -276,7 +276,7 @@ class SceneDataManager {
         const tlasArrayByte: ArrayBuffer = new ArrayBuffer(arraySize);
         this.m_tlas.writeNodesToArray(tlasArrayByte);
 
-        this.m_tlasBuffer = IGPU.get().createBuffer({
+        this.m_tlasBuffer = IGPU.createBuffer({
             size: arraySize,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
         });

--- a/src/core/scene/scene-data-manager.ts
+++ b/src/core/scene/scene-data-manager.ts
@@ -23,7 +23,8 @@ class SceneDataManager {
         this.m_blasOffsetToMeshIDMap = new Map<number, number>();
         this.m_meshIDToBLAS = new Map<number, BLAS>();
 
-        this.m_totalMapCount = 0;
+        //dummy texture
+        this.m_totalMapCount = 1;
 
         this._updateVertexBuffer();
     }
@@ -151,6 +152,8 @@ class SceneDataManager {
         this.m_blasOffsetToMeshIDMap = new Map<number, number>();
         this.m_meshIDToBLAS = new Map<number, BLAS>();
         // TODO: currently tlas cpu side does not get cleared
+
+        this.m_totalMapCount = 1;
 
         this.m_vertexBuffer.destroy();
         this.m_vertexInfoBuffer.destroy();
@@ -298,7 +301,7 @@ class SceneDataManager {
 
         this.m_texture = IGPU.get().createTexture(texDescriptor);
 
-        let textureCount: number = 0;
+        let textureCount: number = 1;
         // NOTE: Texture copy order matters rn due to the use of total map count.
         // TODO: Store texture indices.
         this.m_materials.forEach(mat => {


### PR DESCRIPTION
Added a way to support empty scenes.

- Added a createBuffer wrapper that doen't allow for 0 sized buffers creation. Creates instead a 1024byte buffer and returns it.
- Adjusted the textures array to always have a texture. It should be initialized to a black 1024x1024 texture.
- Adjusted the tlas creation to check if we are accessing an undefined node.